### PR TITLE
make neo-cli run with systemd on linux

### DIFF
--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -11,7 +11,9 @@ namespace Neo
 
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            using (FileStream fs = new FileStream("error.log", FileMode.Create, FileAccess.Write, FileShare.None))
+            var configBasePath = Environment.GetEnvironmentVariable("NEOCLI_BASEPATH");
+            var logFile = Path.Combine(configBasePath,"error.log");
+            using (FileStream fs = new FileStream(logFile, FileMode.Create, FileAccess.Write, FileShare.None))
             using (StreamWriter w = new StreamWriter(fs))
             {
                 PrintErrorLogs(w, (Exception)e.ExceptionObject);

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -103,11 +103,11 @@ namespace Neo.Services
         public void Run(string[] args)
         {
             OnStart(args);
-            RunConsole();
+            RunConsole(args);
             OnStop();
         }
 
-        private void RunConsole()
+        private void RunConsole(string[] args)
         {
             bool running = true;
 #if NET461
@@ -120,32 +120,44 @@ namespace Neo.Services
             Console.WriteLine($"{ServiceName} Version: {ver}");
             Console.WriteLine();
 
+            var withInput = true;
+            foreach (String arg in args)
+            {
+                Console.WriteLine(arg);
+                if (arg == "noinput")
+                {
+                    withInput = false;
+                }
+            }
+
             while (running)
             {
-                if (ShowPrompt)
+                if (withInput == true)
                 {
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.Write($"{Prompt}> ");
-                }
+                    if (ShowPrompt)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Green;
+                        Console.Write($"{Prompt}> ");
+                    }
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    string line = Console.ReadLine().Trim();
+                    Console.ForegroundColor = ConsoleColor.White;
 
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                string line = Console.ReadLine().Trim();
-                Console.ForegroundColor = ConsoleColor.White;
-
-                string[] args = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (args.Length == 0)
-                    continue;
-                try
-                {
-                    running = OnCommand(args);
-                }
-                catch (Exception ex)
-                {
+                    string[] inputArgs = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (inputArgs.Length == 0)
+                        continue;
+                    try
+                    {
+                        running = OnCommand(inputArgs);
+                    }
+                    catch (Exception ex)
+                    {
 #if DEBUG
-                    Console.WriteLine($"error: {ex.Message}");
+                        Console.WriteLine($"error: {ex.Message}");
 #else
                     Console.WriteLine("error");
 #endif
+                    }
                 }
             }
 

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -2,7 +2,6 @@
 using Neo.Network;
 using System;
 using System.IO;
-
 namespace Neo
 {
     internal class Settings
@@ -15,7 +14,14 @@ namespace Neo
 
         static Settings()
         {
-            IConfigurationSection section = new ConfigurationBuilder().AddJsonFile("config.json").Build().GetSection("ApplicationConfiguration");
+
+            var configBasePath = Environment.GetEnvironmentVariable("NEOCLI_BASEPATH");
+            var builder = new ConfigurationBuilder();
+            if (configBasePath != null) {
+                builder.SetBasePath(configBasePath);
+            }
+
+            IConfigurationSection section = builder.AddJsonFile("config.json").Build().GetSection("ApplicationConfiguration");
             Default = new Settings(section);
         }
 
@@ -35,7 +41,14 @@ namespace Neo
         public PathsSettings(IConfigurationSection section)
         {
             this.Chain = section.GetSection("Chain").Value;
-            this.ApplicationLogs = Path.Combine(AppContext.BaseDirectory, $"ApplicationLogs_{Message.Magic:X8}");
+            var configBasePath = Environment.GetEnvironmentVariable("NEOCLI_BASEPATH");
+            if (configBasePath != null)
+            {
+                this.ApplicationLogs = Path.Combine(configBasePath, $"ApplicationLogs_{Message.Magic:X8}");
+            } else {
+                this.ApplicationLogs = Path.Combine(AppContext.BaseDirectory, $"ApplicationLogs_{Message.Magic:X8}");    
+            }
+
         }
     }
 

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -29,6 +29,9 @@
 
   <ItemGroup>
     <PackageReference Include="Neo" Version="2.7.1" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.sln
+++ b/neo-cli/neo-cli.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 15.00
+# Visual Studio 2017
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "neo-cli", "neo-cli.csproj", "{41EBF708-1DD7-48C9-8B0D-167C5C7B5B3F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{41EBF708-1DD7-48C9-8B0D-167C5C7B5B3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41EBF708-1DD7-48C9-8B0D-167C5C7B5B3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41EBF708-1DD7-48C9-8B0D-167C5C7B5B3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41EBF708-1DD7-48C9-8B0D-167C5C7B5B3F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- [x] added `NEOCLI_BASEPATH ` environment variable to allow neo-cli to read config.json from different directory other than the base directory where the neo-cli.dll is running from.
- [x] add `noinput` argument when running neo-cli to allow it to run with systemd.  

todo:
- [ ] error.log path